### PR TITLE
formatDay allows use of date formatters

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -229,11 +229,15 @@ dayFormats =
 
 # formats day strings in the format of: 2014-08-15
 formatDay = (day, formatString) ->
-  return day if !dayFormats[formatString] or !day
+  formats = _.extend {}, dateFormats, dayFormats
+  return day if !formats[formatString] or !day
   parts = day.match /^(\d{4})\-(\d{1,2})\-(\d{1,2})$/
   return day if !parts
   date = new Date(+parts[1], +parts[2] - 1, +parts[3])
-  dayFormats[formatString](date)
+  format = formats[formatString]
+  tzid = clock.utc.tzid
+  return _isFunction(format) and format(date, tzid) or _formatDate(date, format, tzid)
+
 
 normalizePhone = (phone) ->
   if phone?

--- a/test/goodeggs_formatters.test.coffee
+++ b/test/goodeggs_formatters.test.coffee
@@ -12,14 +12,25 @@ describe 'goodeggs-formatters', ->
     expect(f.formatPhone('415')).to.eql '415'
     expect(f.formatPhone('+14153208262')).to.eql '415-320-8262'
 
-  it 'formatDay', ->
-    expect(f.formatDay('2014-11-29', 'shortShoppingDay')).to.eql 'Sat 11/29'
-    expect(f.formatDay('2014-1-1', 'shortShoppingDay')).to.eql 'Wed 1/1'
-    expect(f.formatDay('2014-01-1', 'shortShoppingDay')).to.eql 'Wed 1/1'
-    expect(f.formatDay('2014-01-01', 'shortShoppingDay')).to.eql 'Wed 1/1'
-    expect(f.formatDay('2014-1-01', 'shortShoppingDay')).to.eql 'Wed 1/1'
-    expect(f.formatDay('2014-12-09', 'shortShoppingDay')).to.eql 'Tue 12/9'
-    expect(f.formatDay('2014-12-31', 'shortShoppingDay')).to.eql 'Wed 12/31'
+  describe 'formatDay', ->
+    describe 'shortShoppingDay', ->
+      it 'formats correctly', ->
+        expect(f.formatDay('2014-11-29', 'shortShoppingDay')).to.eql 'Sat 11/29'
+        expect(f.formatDay('2014-1-1', 'shortShoppingDay')).to.eql 'Wed 1/1'
+        expect(f.formatDay('2014-01-1', 'shortShoppingDay')).to.eql 'Wed 1/1'
+        expect(f.formatDay('2014-01-01', 'shortShoppingDay')).to.eql 'Wed 1/1'
+        expect(f.formatDay('2014-1-01', 'shortShoppingDay')).to.eql 'Wed 1/1'
+        expect(f.formatDay('2014-12-09', 'shortShoppingDay')).to.eql 'Tue 12/9'
+        expect(f.formatDay('2014-12-31', 'shortShoppingDay')).to.eql 'Wed 12/31'
+
+    describe 'shortMonthDay', ->
+      it 'formats correctly', ->
+        expect(f.formatDay('2014-12-31', 'shortMonthDay')).to.eql 'Dec 31'
+        expect(f.formatDay('2017-02-01', 'shortMonthDay')).to.eql 'Feb 1'
+
+    describe 'twoLetterDayOfTheWeek', ->
+      it 'formats correctly', ->
+        expect(f.formatDay('2017-02-01', 'twoLetterDayOfTheWeek')).to.eql 'we'
 
   it 'formatDate', ->
     expect(f.formatDate('2014-3-8', 'mailChimpDate', clock.utc.tzid)).to.eql '03/08/2014'


### PR DESCRIPTION
Adding all of the utility of `formatDate` to `formatDay` (the time formatters will be somewhat useless, but I chose not to filter them out).